### PR TITLE
Strip doc path from doxygen

### DIFF
--- a/doc/doxygen.cfg
+++ b/doc/doxygen.cfg
@@ -153,7 +153,8 @@ FULL_PATH_NAMES        = YES
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
 STRIP_FROM_PATH        = $(SRCDIR)/src \
-                         $(SRCDIR)/include
+                         $(SRCDIR)/include \
+                         $(SRCDIR)/doc
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which


### PR DESCRIPTION
Otherwise some md_\* files with the full path are generated. Generally,
it seems those are the files that are actually empty as there is a
only doxygen group in there: development and logic
