### PR TITLE
UART: Add buffer to egress path

### DIFF
--- a/src/backend_uart/doc/logic.md
+++ b/src/backend_uart/doc/logic.md
@@ -33,13 +33,3 @@ The following parameters are available.
 | BUFFER_OUT_DEPTH | Size of the output buffer (i.e. the buffer between the FPGA and the host) in bytes. Default: 4096 bytes |
 
 
-Resource Utilization
---------------------
-
-The following resource utilization of the hardware logic was measured
-on a Xilinx 7 Series device:
-
-| LUTs | Registers | BRAMs |
-|------|-----------|-------|
-| 323  | 154       | 2     |
-

--- a/src/backend_uart/doc/logic.md
+++ b/src/backend_uart/doc/logic.md
@@ -30,6 +30,7 @@ The following parameters are available.
 | BAUD        | Baud rate (default: 115200)         |
 | XILINX_TARGET_DEVICE | Xilinx target device. Valid options: `7SERIES` for Xilinx 7 series devices (Virtex, Kintex, Artix). Default: `7SERIES` |
 | WIDTH       | Width of the FIFO (`fifo_*`) ports. Supported values: 8 and 16. Default: 8 |
+| BUFFER_OUT_DEPTH | Size of the output buffer (i.e. the buffer between the FPGA and the host) in bytes. Default: 4096 bytes |
 
 
 Resource Utilization

--- a/src/backend_uart/logic/backend_uart.core
+++ b/src/backend_uart/logic/backend_uart.core
@@ -6,6 +6,7 @@ depend =
   glip:common:channel
   glip:common:scaler
   glip:common:credit
+  glip:common:fifo_sync
 
 [fileset src_files]
 file_type = verilogSource

--- a/src/backend_uart/logic/verilog/glip_uart_toplevel.v
+++ b/src/backend_uart/logic/verilog/glip_uart_toplevel.v
@@ -50,6 +50,7 @@ module glip_uart_toplevel
   #(parameter FREQ_CLK_IO = 32'hx,
     parameter BAUD = 115200,
     parameter WIDTH = 8,
+    parameter BUFFER_OUT_DEPTH = 4*1024,
     parameter XILINX_TARGET_DEVICE = "7SERIES")
    (
     // Clock & Reset
@@ -121,6 +122,9 @@ module glip_uart_toplevel
    wire [7:0]    egress_in_data;
    wire          egress_in_valid;
    wire          egress_in_ready;
+   wire [7:0]    egress_in_buffered_data;
+   wire          egress_in_buffered_valid;
+   wire          egress_in_buffered_ready;
    wire [7:0]    egress_out_data;
    wire          egress_out_enable;
    wire          egress_out_done;
@@ -135,12 +139,16 @@ module glip_uart_toplevel
    wire          in_buffer_empty;
    wire          out_fifo_full;
    wire          out_fifo_empty;
+   wire          out_buffer_full;
+   wire          out_buffer_empty;
    assign ingress_out_ready = ~in_buffer_almost_full;
    assign ingress_buffer_valid = ~in_buffer_empty;
    assign ingress_buffer_ready = ~in_fifo_full;
    assign fifo_in_valid_scale = ~in_fifo_empty;
    assign egress_in_valid = ~out_fifo_empty;
    assign fifo_out_ready_scale = ~out_fifo_full;
+   assign egress_in_buffered_valid = ~out_buffer_empty;
+   assign egress_in_ready = ~out_buffer_full;
 
    // We are always ready to send
    assign uart_rts_n = 1'b0;
@@ -250,7 +258,7 @@ module glip_uart_toplevel
              .ingress_in_ready          (ingress_in_ready),
              .ingress_out_data          (ingress_out_data[7:0]),
              .ingress_out_valid         (ingress_out_valid),
-             .egress_in_ready           (egress_in_ready),
+             .egress_in_ready           (egress_in_buffered_ready),
              .egress_out_data           (egress_out_data[7:0]),
              .egress_out_enable         (egress_out_enable),
              .ctrl_logic_rst            (ctrl_logic_rst),
@@ -262,8 +270,8 @@ module glip_uart_toplevel
              .ingress_in_data           (ingress_in_data[7:0]),
              .ingress_in_valid          (ingress_in_valid),
              .ingress_out_ready         (ingress_out_ready),
-             .egress_in_data            (egress_in_data[7:0]),
-             .egress_in_valid           (egress_in_valid),
+             .egress_in_data            (egress_in_buffered_data[7:0]),
+             .egress_in_valid           (egress_in_buffered_valid),
              .egress_out_done           (egress_out_done),
              .transfer_in               (transfer_in));
 
@@ -386,5 +394,19 @@ module glip_uart_toplevel
       .WRCLK       (clk),
       .WREN        (out_fifo_wren)
       );
+
+   oh_fifo_sync
+     #(.DW(8),.DEPTH(BUFFER_OUT_DEPTH))
+   u_out_buffer
+     (.clk       (clk_io),
+      .nreset    (!rst),
+      .din       (egress_in_data),
+      .wr_en     (egress_in_valid),
+      .rd_en     (egress_in_buffered_ready),
+      .dout      (egress_in_buffered_data),
+      .full      (out_buffer_full),
+      .prog_full (),
+      .empty     (out_buffer_empty),
+      .rd_count  ());
 
 endmodule // glip_uart_toplevel

--- a/src/common/logic/fifo/fifo_sync.core
+++ b/src/common/logic/fifo/fifo_sync.core
@@ -1,0 +1,11 @@
+CAPI=1
+[main]
+name = glip:common:fifo_sync
+
+[fileset src_files]
+file_type = verilogSource
+usage = sim synth
+files =
+  verilog/oh_fifo_sync.v
+  verilog/oh_memory_dp.v
+  verilog/oh_memory_ram.v

--- a/src/common/logic/fifo/verilog/oh_fifo_sync.v
+++ b/src/common/logic/fifo/verilog/oh_fifo_sync.v
@@ -1,0 +1,76 @@
+//#############################################################################
+//# Function: Synchronous FIFO                                                #
+//#############################################################################
+//# Author:   Andreas Olofsson                                                #
+//# License:  MIT (see LICENSE file in OH! repository)                        #
+//#############################################################################
+
+module oh_fifo_sync #(parameter DW        = 104,      //FIFO width
+                      parameter DEPTH     = 32,       //FIFO depth
+                      parameter PROG_FULL = (DEPTH/2),//prog_full threshold
+                      parameter AW = $clog2(DEPTH)    //rd_count width
+                      )
+(
+   input               clk, // clock
+   input               nreset, // active high async reset
+   input [DW-1:0]      din, // data to write
+   input               wr_en, // write fifo
+   input               rd_en, // read fifo
+   output [DW-1:0]     dout, // output data (next cycle)
+   output              full, // fifo full
+   output              prog_full, // fifo is almost full
+   output              empty, // fifo is empty
+   output reg [AW-1:0] rd_count     // valid entries in fifo
+ );
+
+   reg [AW-1:0]        wr_addr;
+   reg [AW-1:0]        rd_addr;
+   wire                fifo_read;
+   wire                fifo_write;
+
+   assign empty       = (rd_count[AW-1:0] == 0);
+   assign prog_full   = (rd_count[AW-1:0] >= PROG_FULL);
+   assign full        = (rd_count[AW-1:0] == (DEPTH-1));
+   assign fifo_read   = rd_en & ~empty;
+   assign fifo_write  = wr_en & ~full;
+
+   always @ ( posedge clk or negedge nreset)
+     if(!nreset)
+       begin
+          wr_addr[AW-1:0]   <= 'd0;
+          rd_addr[AW-1:0]   <= 'b0;
+          rd_count[AW-1:0]  <= 'b0;
+       end
+     else if(fifo_write & fifo_read)
+       begin
+          wr_addr[AW-1:0] <= wr_addr[AW-1:0] + 'd1;
+          rd_addr[AW-1:0] <= rd_addr[AW-1:0] + 'd1;
+       end
+     else if(fifo_write)
+       begin
+          wr_addr[AW-1:0] <= wr_addr[AW-1:0]  + 'd1;
+          rd_count[AW-1:0]<= rd_count[AW-1:0] + 'd1;
+       end
+     else if(fifo_read)
+       begin
+          rd_addr[AW-1:0] <= rd_addr[AW-1:0]  + 'd1;
+          rd_count[AW-1:0]<= rd_count[AW-1:0] - 'd1;
+       end
+
+   // GENERIC DUAL PORTED MEMORY
+   oh_memory_dp
+     #(.DW(DW),
+       .DEPTH(DEPTH))
+   mem (// read port
+        .rd_dout        (dout[DW-1:0]),
+        .rd_clk         (clk),
+        .rd_en          (1'b1),
+        .rd_addr        (rd_addr[AW-1:0]),
+        // write port
+        .wr_clk         (clk),
+        .wr_en          (fifo_write),
+        .wr_wem         ({(DW){1'b1}}),
+        .wr_addr        (wr_addr[AW-1:0]),
+        .wr_din         (din[DW-1:0]));
+
+endmodule // oh_fifo_sync

--- a/src/common/logic/fifo/verilog/oh_memory_dp.v
+++ b/src/common/logic/fifo/verilog/oh_memory_dp.v
@@ -1,0 +1,41 @@
+//#############################################################################
+//# Function: Dual Port Memory                                                #
+//#############################################################################
+//# Author:   Andreas Olofsson                                                #
+//# License:  MIT (see LICENSE file in OH! repository)                        #
+//#############################################################################
+
+module oh_memory_dp # (parameter DW    = 104,      //memory width
+                       parameter DEPTH = 32,       //memory depth
+                       parameter PROJ  = "",       //project name
+                       parameter MCW   = 8,         //repair/config vector width
+                       parameter AW    = $clog2(DEPTH) // address bus width
+                       )
+   (// Memory interface (dual port)
+    input           wr_clk, //write clock
+    input           wr_en, //write enable
+    input [DW-1:0]  wr_wem, //per bit write enable
+    input [AW-1:0]  wr_addr,//write address
+    input [DW-1:0]  wr_din, //write data
+    input           rd_clk, //read clock
+    input           rd_en, //read enable
+    input [AW-1:0]  rd_addr,//read address
+    output [DW-1:0] rd_dout //read output data
+    );
+
+   oh_memory_ram
+     #(.DW(DW), .DEPTH(DEPTH))
+   memory_dp
+     (//read port
+      .rd_dout  (rd_dout[DW-1:0]),
+      .rd_clk   (rd_clk),
+      .rd_en    (rd_en),
+      .rd_addr  (rd_addr[AW-1:0]),
+      //write port
+      .wr_en    (wr_en),
+      .wr_clk   (wr_clk),
+      .wr_addr  (wr_addr[AW-1:0]),
+      .wr_wem   (wr_wem[DW-1:0]),
+      .wr_din   (wr_din[DW-1:0]));
+
+endmodule // oh_memory_dp

--- a/src/common/logic/fifo/verilog/oh_memory_ram.v
+++ b/src/common/logic/fifo/verilog/oh_memory_ram.v
@@ -1,0 +1,39 @@
+//#############################################################################
+//# Function: Generic RAM memory                                              #
+//#############################################################################
+//# Author:   Andreas Olofsson                                                #
+//# License:  MIT  (see LICENSE file in OH! repository)                       #
+//#############################################################################
+
+module oh_memory_ram  # (parameter DW    = 104,           //memory width
+                         parameter DEPTH = 32,            //memory depth
+                         parameter AW    = $clog2(DEPTH)  // address width
+                         )
+   (// read-port
+    input               rd_clk,// rd clock
+    input               rd_en, // memory access
+    input [AW-1:0]      rd_addr, // address
+    output reg [DW-1:0] rd_dout, // data output
+    // write-port
+    input               wr_clk,// wr clock
+    input               wr_en, // memory access
+    input [AW-1:0]      wr_addr, // address
+    input [DW-1:0]      wr_wem, // write enable vector
+    input [DW-1:0]      wr_din // data input
+    );
+
+   reg [DW-1:0]        ram    [DEPTH-1:0];
+   integer             i;
+
+   //registered read port
+   always @ (posedge rd_clk)
+     if(rd_en)
+       rd_dout[DW-1:0] <= ram[rd_addr[AW-1:0]];
+
+   //write port with vector enable
+   always @(posedge wr_clk)
+     for (i=0;i<DW;i=i+1)
+       if (wr_en & wr_wem[i])
+         ram[wr_addr[AW-1:0]][i] <= wr_din[i];
+
+endmodule // oh_memory_ram


### PR DESCRIPTION
The buffer is of configurable depth and based on the OH!
library. Slight modifications are to turn it into a
first-word-fall-through FIFO and removing external defines.
