### PR TITLE
[WIP] Draft FX3 firmware interface

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,7 +20,8 @@ AM_LDFLAGS += $(libusb_LIBS)
 endif
 
 if BACKEND_CYPRESSFX3
-libglip_la_SOURCES += backend_cypressfx3/sw/backend_cypressfx3.c
+libglip_la_SOURCES += backend_cypressfx3/sw/backend_cypressfx3.c \
+	backend_cypressfx3/sw/interface.c
 AM_CFLAGS += $(libusb_CFLAGS)
 AM_LDFLAGS += $(libusb_LIBS)
 endif

--- a/src/backend_cypressfx3/sw/interface.c
+++ b/src/backend_cypressfx3/sw/interface.c
@@ -1,0 +1,104 @@
+#include "interface.h"
+
+#include <string.h>
+
+static const int USB_TX_TIMEOUT_MS = 1000; /* 1 second */
+
+static uint8_t optimsoc_get_fifo_width(struct libusb_device_descriptor * desc ) {
+    return desc->iSerialNumber;
+}
+
+static int optimsoc_reset_communication(struct glip_ctx * ctx,
+        struct libusb_device_handle * dev) {
+    int rv;
+    rv = libusb_control_transfer(dev, 0x40, 0x60,
+                                 (1 << 0), 0, 0, 0, USB_TX_TIMEOUT_MS);
+    if (rv < 0) {
+        err(ctx, "Unable to send USB control message to reset system "
+            "(r=1). Error %d: %s\n", rv, libusb_error_name(rv));
+        return -1;
+    }
+
+    rv = libusb_control_transfer(dev, 0x40, 0x60,
+                                 (0 << 0), 0, 0, 0, USB_TX_TIMEOUT_MS);
+    if (rv < 0) {
+        err(ctx, "Unable to send USB control message to reset system (r=0). "
+            "Error %d: %s\n", rv, libusb_error_name(rv));
+        return -1;
+    }
+
+    return 0;
+}
+
+
+static int optimsoc_reset_logic(struct glip_ctx * ctx,
+        struct libusb_device_handle * dev) {
+    int rv;
+
+    /* set reset signal */
+    rv = libusb_control_transfer(dev, 0x40, 0x60,
+                                 (1 << 1), 0, 0, 0, USB_TX_TIMEOUT_MS);
+    if (rv < 0) {
+        err(ctx, "Unable to send USB control message to reset system "
+                 "(r=1). Error %d: %s\n", rv, libusb_error_name(rv));
+        return -1;
+    }
+
+    /* unset reset signal */
+    rv = libusb_control_transfer(dev, 0x40, 0x60,
+                                 (0 << 1), 0, 0, 0, USB_TX_TIMEOUT_MS);
+
+    if (rv < 0) {
+        err(ctx, "Unable to send USB control message to reset system (r=0). "
+            "Error %d: %s\n", rv, libusb_error_name(rv));
+        return -1;
+    }
+
+    return 0;
+}
+
+static uint8_t ztex_get_fifo_width(struct libusb_device_descriptor * desc) {
+    (void) desc;
+    return 2;
+}
+
+static int ztex_reset_communication(struct glip_ctx * ctx,
+        struct libusb_device_handle * dev) {
+    return 0;
+}
+
+static int ztex_reset_logic(struct glip_ctx * ctx,
+        struct libusb_device_handle * dev) {
+    return 0;
+}
+
+static struct firmware_interface interfaces[] = {
+    {
+        .name = "OpTiMSoC",
+        .get_fifo_width = optimsoc_get_fifo_width,
+        .reset_communication = optimsoc_reset_communication,
+        .reset_logic = optimsoc_reset_logic,
+        .wr_ep = 0x01 | LIBUSB_ENDPOINT_OUT,
+        .rd_ep = 0x01 | LIBUSB_ENDPOINT_IN
+    },
+    {
+        .name = "ZTEX",
+        .get_fifo_width = ztex_get_fifo_width,
+        .reset_communication = ztex_reset_communication,
+        .reset_logic = ztex_reset_logic,
+        .wr_ep = 0x02 | LIBUSB_ENDPOINT_OUT,
+        .rd_ep = 0x04 | LIBUSB_ENDPOINT_IN
+    },
+    {}
+};
+
+struct firmware_interface *get_firmware_interface(const char* name) {
+    for (int idx = 0; interfaces[idx].name != 0; idx++) {
+        struct firmware_interface *fwif = &interfaces[idx];
+        if (strncmp(name, fwif->name, strlen(fwif->name)) == 0) {
+            return fwif;
+        }
+    }
+
+    return 0;
+}

--- a/src/backend_cypressfx3/sw/interface.h
+++ b/src/backend_cypressfx3/sw/interface.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "glip-protected.h"
+
+#include <stdint.h>
+#include <libusb.h>
+
+struct firmware_interface {
+    const char *name;
+    uint8_t (*get_fifo_width)(struct libusb_device_descriptor * /* desc */);
+    int (*reset_communication)(struct glip_ctx * /* ctx */,
+            struct libusb_device_handle * /* dev */);
+    int (*reset_logic)(struct glip_ctx * /* ctx */,
+            struct libusb_device_handle * /* dev */);
+    int wr_ep;
+    int rd_ep;
+};
+
+struct firmware_interface *get_firmware_interface(const char* name);


### PR DESCRIPTION
It not make sense to load our firmware to the ZTEX boards, because we
would loose the ability to load the FPGA bitstream. Also we don't want
to include this in our firmware. Finally, we want to support the
default ZTEX firmware.

Hence, this drafts one possibility to allow for different firmware
interfaces. The differences between interfaces are:

 * How GPIO pins are accessed

 * Which endpoints are used for the FIFOs

If we anticipate only ZTEX and our firmware, I would suggest we
explore adopting the ZTEX interface. Else this is maybe a direction we
want to go.